### PR TITLE
test: Use non-deprecated headers

### DIFF
--- a/test/core/report/abstract-webhook.spec.ts
+++ b/test/core/report/abstract-webhook.spec.ts
@@ -70,10 +70,10 @@ describe("Report Webhooks", () => {
 
   it("should extract webhook info when given as headers", () => {
     requestMock.headers = {
-      "X-swingletree-org": "org",
-      "X-swingletree-repo": "repo",
-      "X-swingletree-sha": "sha",
-      "X-swingletree-branch": "branch"
+      "swingletree-org": "org",
+      "swingletree-repo": "repo",
+      "swingletree-sha": "sha",
+      "swingletree-branch": "branch"
     };
     requestMock.query = {};
 


### PR DESCRIPTION
### Description
There are two tests that check whether the coordinate transfer works when they are passed as HTTP headers. One is for the deprecated headers (with "X-"), the other should be for the non-deprecated headers. Both both tests use "X-" headers.

This change makes the "current" test use the non-X headers.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
